### PR TITLE
Fix/extract text

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/emcniece/ha_pdf",
   "requirements": ["PyPDF2~=3.0.0"],
   "codeowners": ["@emcniece"],
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/sensor.py
+++ b/sensor.py
@@ -114,7 +114,7 @@ class PDFFileSensor(Entity):
                     page = pdf.pages[int(self._pdf_page)]
                 except IndexError:
                     _LOGGER.error("PDF Page %s does not exist in file: %s", self._pdf_page, self._file_path)
-                text = page.extractText()
+                text = page.extract_text()
         except (IndexError, FileNotFoundError, IsADirectoryError, UnboundLocalError):
             _LOGGER.warning(
                 "File or data not present at the moment: %s",


### PR DESCRIPTION
Restores the text extraction capability for PyPDF2 v3.x.

Resolves https://github.com/emcniece/ha_pdf/issues/5